### PR TITLE
Maps version feature

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     "userInterfaceStyle": "light",
     "splash": {
       "image": "./assets/flight_search.png",
-      "resizeMode": "center",
+      "resizeMode": "contain",
       "backgroundColor": "#78C0E0"
     },
     "updates": {
@@ -30,10 +30,6 @@
         "backgroundColor": "#78C0E0"
       }
     },
-    "permissions": [
-      "ACCESS_FINE_LOCATION",
-      "WRITE_EXTERNAL_STORAGE"
-    ],
     "web": {
       "favicon": "./assets/flight_search.png"
     },
@@ -44,3 +40,5 @@
     }
   }
 }
+
+

--- a/eas.json
+++ b/eas.json
@@ -11,6 +11,9 @@
       }
     },
     "preview": {
+      "android" : {
+        "buildType" : "apk"
+      },
       "distribution": "internal",
       "ios": {
         "resourceClass": "m-medium"
@@ -23,6 +26,8 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react": "18.1.0",
         "react-native": "0.70.5",
         "react-native-dropdown-select-list": "^2.0.4",
-        "react-native-maps": "^1.4.0",
+        "react-native-maps": "1.3.2",
         "react-native-safe-area-context": "4.4.1",
         "react-native-screens": "~3.18.0",
         "react-native-shadow-generator": "^1.1.2",
@@ -10619,9 +10619,9 @@
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
     },
     "node_modules/react-native-maps": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.4.0.tgz",
-      "integrity": "sha512-asP6oVx9uF4E9U22j40q0AcSJ4v3hPBPCg1kPdlbckGXGj+z8dwwdPkQi3hUpl94odlR//v60Sw6PAEYv8zSxw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.3.2.tgz",
+      "integrity": "sha512-NB7HGRZOgxxXCWzrhIVucx/bsrEWANvk3DLci1ov4P9MQnEVQYQCCkTxsnaEvO191GeBOCRDyYn6jckqbfMtmg==",
       "dependencies": {
         "@types/geojson": "^7946.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react": "18.1.0",
     "react-native": "0.70.5",
     "react-native-dropdown-select-list": "^2.0.4",
-    "react-native-maps": "^1.4.0",
+    "react-native-maps": "1.3.2",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "~3.18.0",
     "react-native-shadow-generator": "^1.1.2",


### PR DESCRIPTION
Changed react-native-maps version 1.3.2 to replace the new 1.4.0 unsupported by expo. Fixed errors that expo doctor found. 